### PR TITLE
fix memory leak when not connected to the network

### DIFF
--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -264,7 +264,14 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
 #endif
   tcp_arg(pcb, this);
   tcp_err(pcb, &_s_error);
-  size_t err = tcp_connect(pcb, &addr, port,(tcp_connected_fn)&_s_connected);
+  err_t err = tcp_connect(pcb, &addr, port,(tcp_connected_fn)&_s_connected);
+  if (err != ERR_OK) {
+    if (tcp_close(pcb) != ERR_OK) {
+      tcp_abort(pcb);
+    }
+    pcb = NULL;
+  }
+
   return (ERR_OK == err);
 }
 


### PR DESCRIPTION
When a connection fails, the memory used for pcb was not released. Now it calls tcp_close(pcb) to free resources.